### PR TITLE
Convert string bandwidth value to integer before JSON serialization

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -126,7 +126,7 @@ class Client extends EventEmitter {
           sendOffer = true;
           var offer = await pc.getLocalDescription();
           logger.debug('Send offer sdp => ' + offer.sdp);
-          int bw = bandwidth;
+          int bw = int.parse(bandwidth);
           var options = {
             'audio': audio,
             'video': video,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -126,12 +126,13 @@ class Client extends EventEmitter {
           sendOffer = true;
           var offer = await pc.getLocalDescription();
           logger.debug('Send offer sdp => ' + offer.sdp);
+          int bw = bandwidth;
           var options = {
             'audio': audio,
             'video': video,
             'screen': screen,
             'codec': codec,
-            'bandwidth': bandwidth,
+            'bandwidth': bw,
           };
           var result = await this._protoo.send('publish',
               {'rid': this._rid, 'jsep': offer.toMap(), 'options': options});


### PR DESCRIPTION
#### Description

Current SDK serializes the bandwidth option value as a string, causing a deserialization error on the server.

#### Reference issue
Fixes deserialization error on the server coming from bandwidth options set in Flutter SDK.
