### PR TITLE
Fixed null transports issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ Add
 
 ```dart
 import 'package:flutter_ion/flutter_ion.dart' as ion;
+import 'package:uuid/uuid.dart';
 
 // Connect to ion-sfu.
 final signal = ion.JsonRPCSignal("ws://ion-sfu:7000/ws");
 
-ion.Client client = await ion.Client.create(sid: "test session", signal: signal);
+final String _uuid = Uuid().v4();
+
+ion.Client client = await ion.Client.create(sid: "test session", uid: _uuid, signal: signal);
 
 client.ontrack = (track, ion.RemoteStream stream) {
     /// mute a remote stream

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -63,6 +63,14 @@ class Client {
       Signal signal,
       Map<String, dynamic> config}) async {
     var client = Client(signal, config);
+
+    client.transports = {
+      RolePub: await Transport.create(
+          role: RolePub, signal: signal, config: config ?? defaultConfig),
+      RoleSub: await Transport.create(
+          role: RoleSub, signal: signal, config: config ?? defaultConfig)
+    };
+
     client.signal.onready = () async {
       if (!client.initialized) {
         client.join(sid, uid);
@@ -112,13 +120,6 @@ class Client {
 
   void join(String sid, String uid) async {
     try {
-      transports = {
-        RolePub: await Transport.create(
-            role: RolePub, signal: signal, config: config ?? defaultConfig),
-        RoleSub: await Transport.create(
-            role: RoleSub, signal: signal, config: config ?? defaultConfig)
-      };
-
       transports[RoleSub].pc.onTrack = (RTCTrackEvent ev) {
         var remote = makeRemote(ev.streams[0], transports[RoleSub]);
         ontrack?.call(ev.track, remote);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: flutter_ion
-version: 0.3.0
+version: 0.3.1
 description: Ion SDK for flutter, For live broadcast, video conference, etc., support mobile/deskop/web.
 homepage: https://github.com/pion/ion-sdk-flutter
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.7.0 <2.14.0"
 
 dependencies:
   events2: ^0.1.3

--- a/test/biz_test.dart
+++ b/test/biz_test.dart
@@ -12,12 +12,12 @@ void main() async {
   var sid = 'test room1';
 
   test('test join', () async {
-    biz.onPeerEvent = (state, peer) {
-      print(
-          'sid ${peer.sid}, peer ${peer.uid} info ${peer.info}, state $state');
-      //expect(peer.uid, uid);
-      //expect(peer.sid, sid);
-    };
+    // biz.onPeerEvent = (state, peer) {
+    //   print(
+    //       'sid ${peer.sid}, peer ${peer.uid} info ${peer.info}, state $state');
+    //   //expect(peer.uid, uid);
+    //   //expect(peer.sid, sid);
+    // };
     var success = await biz.join(
         sid: sid, uid: uid, info: <String, String>{'name': 'flutter_client'});
 


### PR DESCRIPTION
And updated README to show correct usage.

#### Description

Created Client.transports inside Client.create() to fix an issue in Client.negotiate where transports had not yet been created and were being accessed.

README.md was also out of date and did not show the correct usage of Client.create()

Also commented out some test code as BizClient no longer has no definition for onPeerEvent.

#### Reference issue
Fixes #...
