### PR TITLE
onnegotiationneeded error fix

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -94,7 +94,9 @@ class CodecCapabilitySelector {
 
   Map<String, dynamic>? _mline(String kind) {
     var mlist = _session['media'] as List<dynamic>;
-    return mlist.singleWhere((element) => element['type'] == kind,
+//     return mlist.singleWhere((element) => element['type'] == kind,
+//         orElse: () => null);
+    return mlist.firstWhere((element) => element['type'] == kind,
         orElse: () => null);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -94,8 +94,6 @@ class CodecCapabilitySelector {
 
   Map<String, dynamic>? _mline(String kind) {
     var mlist = _session['media'] as List<dynamic>;
-//     return mlist.singleWhere((element) => element['type'] == kind,
-//         orElse: () => null);
     return mlist.firstWhere((element) => element['type'] == kind,
         orElse: () => null);
   }


### PR DESCRIPTION
#### Description
This workaround ensures only the first occurrence of the stream is sent when adding/removing a track. Tested with v0.5.3 using sfu+biz method (ion_cluster_view.dart from example app)

#### Reference issue
Fixes #52 
